### PR TITLE
containerView Search

### DIFF
--- a/UIView+NibLoading.m
+++ b/UIView+NibLoading.m
@@ -39,9 +39,19 @@
 
     NSArray * views = [nib instantiateWithOwner:self options:nil];
     NSAssert(views!=nil, @"UIView+NibLoading : Can't instantiate nib named %@.",nibName);
-    NSAssert(views.count==1, @"UIView+NibLoading : There must be exactly one root container view in %@.",nibName);
-    UIView * containerView = [views objectAtIndex:0];
-    NSAssert([[containerView class] isEqual:[UIView class]], @"UIView+NibLoading : The container view in nib %@ should be a UIView instead of %@. (It's only a container, and it's discarded after loading.)",nibName,[containerView class]);
+
+    // Search for the first encountered UIView based object
+    UIView * containerView = nil;
+    for (id v in views)
+    {
+        if ([v isKindOfClass:[UIView class]])
+        {
+            containerView = v;
+            break;
+        }
+    }
+    
+    NSAssert(containerView != nil, @"UIView+NibLoading : There is no container UIView found at the root of nib %@.",nibName);
     
     [containerView setTranslatesAutoresizingMaskIntoConstraints:NO];
     


### PR DESCRIPTION
I added a search for the first encountered UIView at the root level of the nib, and consider that the containerView (if it exists).

It is not uncommon to have other objects in the first position at root level. One example (which was my case) is with gesture recognizers created in Interface Builder. They are placed at the root, before my container UIView.
