### PR TITLE
Fixed iOS6 crash due to view being associated with multiple parent views

### DIFF
--- a/UIView+NibLoading.m
+++ b/UIView+NibLoading.m
@@ -67,7 +67,12 @@
     
     // reparent the subviews from the nib file
     for (UIView * view in containerView.subviews)
+    {
+	if(view.superview != nil)
+	    [view removeFromSuperview];
+
         [self addSubview:view];
+    }
     
     //re-add constraints, replace containerView with self
     for (NSLayoutConstraint *constraint in constraints)


### PR DESCRIPTION
This should fix the crash in iOS 6 that happens when a NibLoadedView is deallocated. This happens because iOS6 still returns the old container view as it's superview after it has been added to it's new parent. 

This usually either crashes in [NSISEngine removeConstraintWithMarker:] on a device  or "getpid" on the simulator. 
