### PR TITLE
Support for IBDesignable and Swift

### DIFF
--- a/UIView+NibLoading.m
+++ b/UIView+NibLoading.m
@@ -18,7 +18,7 @@
     UINib * nib = associatedNibs[nibName];
     if(nil==nib)
     {
-        nib = [UINib nibWithNibName:nibName bundle:nil];
+        nib = [UINib nibWithNibName:nibName bundle:[NSBundle bundleForClass:self]];
         if(nib)
         {
             NSMutableDictionary * newNibs = [NSMutableDictionary dictionaryWithDictionary:associatedNibs];
@@ -87,7 +87,15 @@
 
 - (void) loadContentsFromNib
 {
-    [self loadContentsFromNibNamed:NSStringFromClass([self class])];
+    NSString *className = NSStringFromClass([self class]);
+    // A Swift class name will be in the format of ModuleName.ClassName
+    // We want to remove the module name so the Nib can have exactly the same file name as the class
+    NSRange range = [className rangeOfString:@"."];
+    if (range.location != NSNotFound)
+    {
+        className = [className substringFromIndex:range.location + range.length];
+    }
+    [self loadContentsFromNibNamed:className];
 }
 
 @end


### PR DESCRIPTION
Hello,

Thanks for the great little library, it's been invaluable with some recent projects.

I've made two small changes to the library with the intention of supporting the new features in Xcode 6 - namely Swift and IBDesignable.
- Added support for the `IBDesignable` annotation by specifying which bundle the NIB should be loaded from. It's a good assumption that the NIBs are located in the same bundle as the class itself.
- Also added support for Swift by making sure the module name is not considered when creating the default NIB name.

Thanks again for the library!

Matt
