### PR TITLE
Reconnect outlet to constraints

### DIFF
--- a/Demo/ColorsViewController.xib
+++ b/Demo/ColorsViewController.xib
@@ -1,182 +1,52 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">12C3006</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3083</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">2083</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBProxyObject</string>
-			<string>IBUIView</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="IBProxyObject" id="372490531">
-				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBProxyObject" id="975951072">
-				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIView" id="191373211">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="IBUIView" id="189829355">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrame">{{20, 20}, {280, 64}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<object class="NSColor" key="IBUIBackgroundColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-						</object>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-					</object>
-				</array>
-				<string key="NSFrame">{{0, 20}, {320, 460}}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="189829355"/>
-				<object class="NSColor" key="IBUIBackgroundColor">
-					<int key="NSColorSpace">3</int>
-					<bytes key="NSWhite">MAA</bytes>
-				</object>
-				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
-				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
-					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
-					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<array key="dict.sortedKeys">
-							<integer value="1"/>
-							<integer value="3"/>
-						</array>
-						<array key="dict.values">
-							<string>{320, 480}</string>
-							<string>{480, 320}</string>
-						</array>
-					</object>
-					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
-					<string key="IBUIDisplayName">Retina 3.5 Full Screen</string>
-					<int key="IBUIType">0</int>
-				</object>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">view</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="191373211"/>
-					</object>
-					<int key="connectionID">3</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">_colorView1</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="189829355"/>
-					</object>
-					<int key="connectionID">17</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1</int>
-						<reference key="object" ref="191373211"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="189829355"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="372490531"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="975951072"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">4</int>
-						<reference key="object" ref="189829355"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.CustomClassName">ColorsViewController</string>
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="-2.CustomClassName">UIResponder</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="4.CustomClassName">ColorView</string>
-				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">18</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">ColorView</string>
-					<string key="superclassName">NibLoadedView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/ColorView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">ColorsViewController</string>
-					<string key="superclassName">UIViewController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/ColorsViewController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NibLoadedView</string>
-					<string key="superclassName">UIView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/NibLoadedView.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">2083</string>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6245" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" promptedForUpgradeToXcode5="NO">
+    <dependencies>
+        <development version="5000" identifier="xcode"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6245"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ColorsViewController">
+            <connections>
+                <outlet property="_colorView1" destination="4" id="17"/>
+                <outlet property="view" destination="1" id="3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="20" width="320" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4" customClass="ColorView">
+                    <rect key="frame" x="20" y="20" width="280" height="84"/>
+                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="19" customClass="TwoViewsWithConfigurableSpace">
+                    <rect key="frame" x="20" y="410" width="280" height="60"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="280" id="PLc-5m-hB7"/>
+                        <constraint firstAttribute="height" constant="60" id="S3h-Cr-6AG"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="space">
+                            <integer key="value" value="20"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="19" secondAttribute="bottom" constant="10" id="bJx-NN-OSf"/>
+                <constraint firstAttribute="centerX" secondItem="19" secondAttribute="centerX" id="vsJ-X9-Ud9"/>
+            </constraints>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="66" y="230"/>
+        </view>
+    </objects>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/Demo/NibLoadedViewDemo.xcodeproj/project.pbxproj
+++ b/Demo/NibLoadedViewDemo.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		37446B6216B1A9AE0040C52F /* ColorsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 37446B6016B1A9AE0040C52F /* ColorsViewController.xib */; };
 		37446B6516B1A9D70040C52F /* ColorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 37446B6416B1A9D70040C52F /* ColorView.m */; };
 		37446B6916B1AAF40040C52F /* ColorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 37446B6816B1AAF40040C52F /* ColorView.xib */; };
+		6360C5A019F7071700BE72AC /* TwoViewsWithConfigurableSpace.m in Sources */ = {isa = PBXBuildFile; fileRef = 6360C59F19F7071700BE72AC /* TwoViewsWithConfigurableSpace.m */; };
+		6360C5A219F7075300BE72AC /* TwoViewsWithConfigurableSpace.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6360C5A119F7075300BE72AC /* TwoViewsWithConfigurableSpace.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +43,9 @@
 		37446B6816B1AAF40040C52F /* ColorView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ColorView.xib; sourceTree = "<group>"; };
 		37446B6A16B27DE70040C52F /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.md; path = ../../README.md; sourceTree = "<group>"; };
 		37446B6C16B27EAF0040C52F /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE.md; path = ../../LICENSE.md; sourceTree = "<group>"; };
+		6360C59E19F7071700BE72AC /* TwoViewsWithConfigurableSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TwoViewsWithConfigurableSpace.h; sourceTree = "<group>"; };
+		6360C59F19F7071700BE72AC /* TwoViewsWithConfigurableSpace.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TwoViewsWithConfigurableSpace.m; sourceTree = "<group>"; };
+		6360C5A119F7075300BE72AC /* TwoViewsWithConfigurableSpace.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TwoViewsWithConfigurableSpace.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -119,6 +124,9 @@
 				37446B5E16B1A9AE0040C52F /* ColorsViewController.h */,
 				37446B5F16B1A9AE0040C52F /* ColorsViewController.m */,
 				37446B6016B1A9AE0040C52F /* ColorsViewController.xib */,
+				6360C59E19F7071700BE72AC /* TwoViewsWithConfigurableSpace.h */,
+				6360C59F19F7071700BE72AC /* TwoViewsWithConfigurableSpace.m */,
+				6360C5A119F7075300BE72AC /* TwoViewsWithConfigurableSpace.xib */,
 			);
 			name = "Demo Code";
 			sourceTree = "<group>";
@@ -178,6 +186,7 @@
 				37446B4E16B1A7630040C52F /* Default.png in Resources */,
 				37446B5016B1A7630040C52F /* Default@2x.png in Resources */,
 				37446B5216B1A7630040C52F /* Default-568h@2x.png in Resources */,
+				6360C5A219F7075300BE72AC /* TwoViewsWithConfigurableSpace.xib in Resources */,
 				37446B6216B1A9AE0040C52F /* ColorsViewController.xib in Resources */,
 				37446B6916B1AAF40040C52F /* ColorView.xib in Resources */,
 			);
@@ -191,6 +200,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				37446B4C16B1A7630040C52F /* AppDelegate.m in Sources */,
+				6360C5A019F7071700BE72AC /* TwoViewsWithConfigurableSpace.m in Sources */,
 				37446B5A16B1A7F50040C52F /* UIView+NibLoading.m in Sources */,
 				37446B6116B1A9AE0040C52F /* ColorsViewController.m in Sources */,
 				37446B6516B1A9D70040C52F /* ColorView.m in Sources */,

--- a/Demo/TwoViewsWithConfigurableSpace.h
+++ b/Demo/TwoViewsWithConfigurableSpace.h
@@ -1,0 +1,21 @@
+//
+//  TwoViewsWithConfigurableSpace.h
+//  NibLoadedViewDemo
+//
+//  Created by meknil on 21.10.14.
+//
+
+#import "UIView+NibLoading.h"
+
+//
+// A view that presents two black squares (as an example for anything else).
+// The space between thes squares is configurable at design- and runtime.
+//
+
+IB_DESIGNABLE
+@interface TwoViewsWithConfigurableSpace : NibLoadedView
+
+// use this property to set the space between the two squares in IB or at runtime
+@property (assign, nonatomic) IBInspectable NSInteger space;
+
+@end

--- a/Demo/TwoViewsWithConfigurableSpace.m
+++ b/Demo/TwoViewsWithConfigurableSpace.m
@@ -1,0 +1,26 @@
+//
+//  TwoViewsWithConfigurableSpace.m
+//  NibLoadedViewDemo
+//
+//  Created by meknil on 21.10.14.
+//
+
+#import "TwoViewsWithConfigurableSpace.h"
+
+@interface TwoViewsWithConfigurableSpace()
+
+@property (strong, nonatomic) IBOutlet NSLayoutConstraint *spaceBetweenViews;
+
+@end
+
+
+@implementation TwoViewsWithConfigurableSpace
+
+
+- (void)setSpace:(NSInteger)space
+{
+    _space = space;
+    self.spaceBetweenViews.constant = space;
+}
+
+@end

--- a/Demo/TwoViewsWithConfigurableSpace.xib
+++ b/Demo/TwoViewsWithConfigurableSpace.xib
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6245" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment defaultVersion="1552" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6245"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TwoViewsWithConfigurableSpace">
+            <connections>
+                <outlet property="spaceBetweenViews" destination="eFT-ib-wx7" id="beZ-Ey-JC3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" userLabel="(Container)">
+            <rect key="frame" x="0.0" y="0.0" width="160" height="60"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mTr-Rx-VWB" userLabel="LeftView">
+                    <rect key="frame" x="20" y="10" width="40" height="40"/>
+                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="40" id="9tJ-zy-mEB"/>
+                        <constraint firstAttribute="width" constant="40" id="ScU-5t-g1N"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Av2-D3-80L" userLabel="RightView">
+                    <rect key="frame" x="100" y="10" width="40" height="40"/>
+                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="40" id="bC6-fG-iFG"/>
+                        <constraint firstAttribute="width" constant="40" id="vb7-NW-pEl"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="mTr-Rx-VWB" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="HGz-dr-Bny"/>
+                <constraint firstItem="mTr-Rx-VWB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="Ja2-lP-8ee"/>
+                <constraint firstItem="Av2-D3-80L" firstAttribute="centerY" secondItem="mTr-Rx-VWB" secondAttribute="centerY" id="WRF-Fq-9Pe"/>
+                <constraint firstItem="Av2-D3-80L" firstAttribute="leading" secondItem="mTr-Rx-VWB" secondAttribute="trailing" constant="40" id="eFT-ib-wx7"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="-55" y="194"/>
+        </view>
+    </objects>
+</document>

--- a/UIView+NibLoading.m
+++ b/UIView+NibLoading.m
@@ -46,7 +46,7 @@ static char kUIViewNibLoading_outletsKey;
     NSAssert(views!=nil, @"UIView+NibLoading : Can't instantiate nib named %@.",nibName);
     objc_setAssociatedObject(self, &kUIViewNibLoading_outletsKey, nil, OBJC_ASSOCIATION_RETAIN);
 
-    // Search for the first encountered UIView based object
+    // Search for the first encountered UIView base object
     UIView * containerView = nil;
     for (id v in views)
     {
@@ -56,38 +56,51 @@ static char kUIViewNibLoading_outletsKey;
             break;
         }
     }
-    
-    NSAssert(containerView != nil, @"UIView+NibLoading : There is no container UIView found at the root of nib %@.",nibName);
+    NSAssert(containerView!=nil, @"UIView+NibLoading : There is no container UIView found at the root of nib %@.",nibName);
     
     [containerView setTranslatesAutoresizingMaskIntoConstraints:NO];
     
     if(CGRectEqualToRect(self.bounds, CGRectZero))
+    {
         // `self` has no size : use the containerView's size, from the nib file
         self.bounds = containerView.bounds;
+    }
     else
+    {
         // `self` has a specific size : resize the containerView to this size, so that the subviews are autoresized.
         containerView.bounds = self.bounds;
+    }
     
-    //save constraints for later
-    NSArray *constraints = containerView.constraints;
+    // Save constraints for later
+    NSArray * constraints = containerView.constraints;
     
     // reparent the subviews from the nib file
     for (UIView * view in containerView.subviews)
-        [self addSubview:view];
-    
-    //re-add constraints, replace containerView with self
-    for (NSLayoutConstraint *constraint in constraints)
     {
-        id firstItem = constraint.firstItem;
-        id secondItem = constraint.secondItem;
-        
+        [self addSubview:view];
+    }
+    
+    // Recreate constraints, replace containerView with self
+    for (NSLayoutConstraint *oldConstraint in constraints)
+    {
+        id firstItem = oldConstraint.firstItem;
+        id secondItem = oldConstraint.secondItem;
         if (firstItem == containerView)
+        {
             firstItem = self;
-        
+        }
         if (secondItem == containerView)
+        {
             secondItem = self;
+        }
         
-        NSLayoutConstraint *newConstraint = [NSLayoutConstraint constraintWithItem:firstItem attribute:constraint.firstAttribute relatedBy:constraint.relation toItem:secondItem attribute:constraint.secondAttribute multiplier:constraint.multiplier constant:constraint.constant];
+        NSLayoutConstraint * newConstraint = [NSLayoutConstraint constraintWithItem:firstItem
+                                                                          attribute:oldConstraint.firstAttribute
+                                                                          relatedBy:oldConstraint.relation
+                                                                             toItem:secondItem
+                                                                          attribute:oldConstraint.secondAttribute
+                                                                         multiplier:oldConstraint.multiplier
+                                                                           constant:oldConstraint.constant];
         [self addConstraint:newConstraint];
         
         // If there was outlet(s) to the old constraint, replace it with the new constraint.


### PR DESCRIPTION
fixes #6

During loading, we replace the layout constraints to the “container view” with new constraints to the actual view.  We must also update any outlets to those constraints.

I’m not entirely satisfied with my solution to list the outlets of the view (by overloading `setValue:forKey:`). @Codewaves’s solution (see #6) involved listing the object properties via `objc_` runtime methods, which is _not that great_ and doesn’t work with ivar outlets.
